### PR TITLE
[APSDK-1785] Simulator crash fixed

### DIFF
--- a/ASScreenRecorder/ASScreenRecorder.m
+++ b/ASScreenRecorder/ASScreenRecorder.m
@@ -178,7 +178,9 @@
             AVVideoMaxKeyFrameIntervalKey: @(300),
             AVVideoProfileLevelKey: AVVideoProfileLevelH264BaselineAutoLevel,
             AVVideoExpectedSourceFrameRateKey: @(30),
+#if !(TARGET_IPHONE_SIMULATOR)
             AVVideoAverageNonDroppableFrameRateKey: @(30),
+#endif
         };
         
         videoSettings = @{


### PR DESCRIPTION
Jira: https://myutest.jira.com/browse/APSDK-1785
- Crash was caused by setting AVVideoAverageNonDroppableFrameRateKey on video compression settings, and this setting is unavailable on simulator
